### PR TITLE
Fixed adding products timing issue

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -18,7 +18,7 @@ const updateNewProductWithDate = async (productId) => {
 
             if (!productDoc) {
                 attempt++;
-                setTimeout(updateDate, 2000)
+                setTimeout(updateDate, 1000)
             } else {
                 await productDoc.update({ date_created: new Date()})
                 console.log('Successfully update new product with date')

--- a/ecosphere-goods/src/components/Dashboard/ProductCatalogContext.js
+++ b/ecosphere-goods/src/components/Dashboard/ProductCatalogContext.js
@@ -29,17 +29,17 @@ const ProductCatalogProvider = ({ children }) => {
 
     const handleAddProduct = async () => {
         try {
-          const storageRef = ref(storage, `images/${Date.now()}`);
-          await uploadString(storageRef, image, 'data_url');
-          const imageUrl = await getDownloadURL(storageRef);
-    
-          const productId = await addNewProduct(name, price, subcategory, imageUrl, category, user.uid)
-          await addProductToProducts(productId)
+            const storageRef = ref(storage, `images/${Date.now()}`);
+            await uploadString(storageRef, image, 'data_url');
+            const imageUrl = await getDownloadURL(storageRef);
+        
+            const productId = await addNewProduct(name, price, subcategory, imageUrl, category, user.uid)
+            await addProductToProducts(productId)
 
-          toast.success('Successfully added new product.')
+            toast.success('Successfully added new product.')
         } catch (error) {
-          console.error(error.message);
-          toast.error('Error adding new product.')
+            console.error(error.message);
+            toast.error('Error adding new product.')
         }
     }
 


### PR DESCRIPTION
**Issue**
- When a new product is added to stripe, it is then added to firebase as a doc after some delay.
- This delay would sometimes cause errors since addNewProduct in the backend would try updating the doc immediately after the product had been created in stripe.

**Fix**
- Created a new function to update the product date using set timeout and giving it 3 attempts to do so before throwing an error