### PR TITLE
Changed from using setTimeout to using a delay instead

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -18,7 +18,8 @@ const updateNewProductWithDate = async (productId) => {
 
             if (!productDoc) {
                 attempt++;
-                setTimeout(updateDate, 1000)
+                await delay(1000)
+                await updateDate()
             } else {
                 await productDoc.update({ date_created: new Date()})
                 console.log('Successfully update new product with date')


### PR DESCRIPTION
- setTimeout helped ensure that the date was updated properly by waiting for the document to be added
- However, there was still a timing issue since in the frontend, we would try fetch the new product right away and so a delay was used to ensure that the product was fully ready before finishing addNewProduct call in the backend