### PR TITLE
Reworked buttons to use children instead of label

### DIFF
--- a/ecosphere-goods/src/components/pages/checkout-page/CheckoutPage.js
+++ b/ecosphere-goods/src/components/pages/checkout-page/CheckoutPage.js
@@ -1,19 +1,17 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { FaArrowLeftLong } from "react-icons/fa6";
 import FinalPricingInformation from './FinalPricingInformation';
 import CartItemDisplay from '../../shopping-cart/CartItemDisplay';
+import BackToBrowsingButton from '../../utility/general-buttons/BackToBrowsingButton'
 
 const CheckoutPage = () => {
     return (
         <div className='flex h-screen w-screen'>
-            <Link 
-                to='/products'
+            <BackToBrowsingButton 
                 className='absolute flex items-center space-x-4 mt-12 ml-10 hover:scale-110 transition-transform ease-in-out duration-300'
             >
-                <FaArrowLeftLong/>
                 <p className='text-dark-brown font-header'>Back To Shopping</p>
-            </Link>
+            </BackToBrowsingButton>
 
             <div className='w-9/13 bg-off-white p-32 pt-24 pb-8 font-header text-dark-brown'>
                 <CartItemDisplay/>

--- a/ecosphere-goods/src/components/pages/checkout-page/DeliveryAddressDialog.js
+++ b/ecosphere-goods/src/components/pages/checkout-page/DeliveryAddressDialog.js
@@ -86,8 +86,8 @@ const DeliveryAddressDialog = ({ open = false, closeDialog }) => {
                             </div>
 
                             <div className='flex font-header justify-between'>
-                                <DialogButton label={'Cancel'} onClick={closeDialog}/>
-                                <DialogButton label={'Submit'} type='submit' loading={loading}/>
+                                <DialogButton onClick={closeDialog}>Cancel</DialogButton>
+                                <DialogButton type='submit' loading={loading}>Submit</DialogButton>
                             </div>
                         </form>
                     </dialog>

--- a/ecosphere-goods/src/components/pages/checkout-page/FinalPricingInformation.js
+++ b/ecosphere-goods/src/components/pages/checkout-page/FinalPricingInformation.js
@@ -79,11 +79,12 @@ const FinalPricingInformation = () => {
                     </div>
 
                     <CheckoutButton  
-                        label={'CHECKOUT'}
                         className='p-3 pl-6 pr-6 rounded-full bg-dark-brown text-off-white tracking-3px hover:scale-105 transition-transform ease-in-out duration-300'
                         loadCheckout={loadCheckout}
                         loading={loading}
-                    />
+                    >
+                        CHECKOUT
+                    </CheckoutButton>
                 </div>
             </div>
 

--- a/ecosphere-goods/src/components/pages/user-portal-page/user-credentials/RegisterEmail.js
+++ b/ecosphere-goods/src/components/pages/user-portal-page/user-credentials/RegisterEmail.js
@@ -71,7 +71,11 @@ const RegisterEmail = ({ backToSignIn }) => {
           <p className={`${(!passwordMatch && confirmPassword !== '') ? 'opacity-100' : 'opacity-0'} text-error`}>* Password does not match!</p>
         </div>
       </Box>
-      <div className='flex justify-center w-4/6'><UncontainedButton label='Sign Up' onClick={ onRegister } loading={loading}/></div>
+      <div className='flex justify-center w-4/6'>
+        <UncontainedButton onClick={ onRegister } loading={loading}>
+          Sign Up
+        </UncontainedButton>
+      </div>
     </div>
   )
 }

--- a/ecosphere-goods/src/components/pages/user-portal-page/user-credentials/RegisterPanel.js
+++ b/ecosphere-goods/src/components/pages/user-portal-page/user-credentials/RegisterPanel.js
@@ -5,7 +5,7 @@ import BackToBrowsingButton from '../../../utility/general-buttons/BackToBrowsin
 const RegisterPanel = ({ backToSignIn }) => {
     return (
         <div className={`w-full flex-shrink-0 space-y-8 p-32`}>
-            <BackToBrowsingButton/>
+            <BackToBrowsingButton>Back To Browsing</BackToBrowsingButton>
             <h1 className='font-LHeader text-header'>Register</h1>
             <RegisterEmail backToSignIn={ backToSignIn }/>
         </div>

--- a/ecosphere-goods/src/components/pages/user-portal-page/user-credentials/SignInPanel.js
+++ b/ecosphere-goods/src/components/pages/user-portal-page/user-credentials/SignInPanel.js
@@ -62,7 +62,7 @@ const SignInPanel = () => {
     
     return (
         <div className='w-full space-y-8 flex-shrink-0 p-32'>
-            <BackToBrowsingButton/>
+            <BackToBrowsingButton>Back To Browsing</BackToBrowsingButton>
             <h1 className='text-header font-LHeader'>Sign In</h1>
             <Box
                 component="form"
@@ -81,7 +81,13 @@ const SignInPanel = () => {
                     <p>Remember Me</p>
                     <p className='font-header cursor-pointer hover:underline'>Forgot Password?</p>
                 </div>
-                <div className='w-4/6'><UncontainedButton onClick={ onSignIn } label='Login' loading={loading}/></div>
+
+                {/** Login Button */}
+                <div className='w-4/6'>
+                    <UncontainedButton onClick={ onSignIn } loading={loading}>
+                        Login
+                    </UncontainedButton>
+                </div>
             </Box>
 
             <div className='flex items-center opacity-40'>
@@ -91,12 +97,14 @@ const SignInPanel = () => {
             </div>
 
             <div className='flex justify-center w-full'>
-                <button 
-                    className='bg-dark-brown bg-opacity-0 border-3 border-dark-brown text-dark-brown p-3 pl-6 pr-6 rounded-full hover:text-off-white hover:bg-opacity-100 transition-all ease-in-out duration-300'
-                    onClick={signInWithGoogle}
-                >
-                        <FaGoogle/>
-                </button>
+                <div className='w-1/6'>
+                    <UncontainedButton 
+                        className='bg-dark-brown bg-opacity-0 border-3 border-dark-brown text-dark-brown p-3 pl-6 pr-6 rounded-full hover:text-off-white hover:bg-opacity-100 transition-all ease-in-out duration-300'
+                        onClick={signInWithGoogle}
+                    >
+                            <FaGoogle/>
+                    </UncontainedButton>
+                </div>
             </div>
         </div>
     )

--- a/ecosphere-goods/src/components/utility/general-buttons/BackToBrowsingButton.js
+++ b/ecosphere-goods/src/components/utility/general-buttons/BackToBrowsingButton.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { FaArrowLeftLong } from "react-icons/fa6";
 import { useNavigate } from 'react-router-dom';
 
-const BackToBrowsingButton = () => {
+const BackToBrowsingButton = ({ children }) => {
     const navigate = useNavigate()
 
     const handleBackClick = () => {
@@ -15,7 +15,7 @@ const BackToBrowsingButton = () => {
             className='absolute p-1 top-8 left-14 flex justify-center items-center space-x-3 hover:-translate-x-4 transition-transform ease-in-out duration-300'
         >
             <FaArrowLeftLong/>
-            <span className='text-dark-brown font-header'>Back to browsing</span>
+            <span className='text-dark-brown font-header'>{ children }</span>
         </button>
     )
 }

--- a/ecosphere-goods/src/components/utility/general-buttons/CheckoutButton.js
+++ b/ecosphere-goods/src/components/utility/general-buttons/CheckoutButton.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { CircularProgress } from '@mui/material'
 
-const CheckOutButton = ({ label= '', loadCheckout, loading = false }) => {
+const CheckOutButton = ({ loadCheckout, loading = false, children }) => {
     return (
         <button 
             className='p-3 pl-6 pr-6 rounded-full bg-dark-brown text-off-white tracking-3px hover:scale-105 transition-transform ease-in-out duration-300'
             onClick={loadCheckout}
         >
             <div className='flex justify-center items-center'>
-                <span className={`${loading && 'opacity-0'}`}>{ label }</span>
+                <span className={`${loading && 'opacity-0'}`}>{ children }</span>
                 <CircularProgress size={18} color='' className={`absolute opacity-0 ${loading && 'opacity-100'}`}/>
             </div>
         </button>

--- a/ecosphere-goods/src/components/utility/general-buttons/ContainedBrownButton.js
+++ b/ecosphere-goods/src/components/utility/general-buttons/ContainedBrownButton.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Button from '@mui/material/Button';
 
-const ContainedBrownButton = ({ clickAction, label }) => {
+const ContainedBrownButton = ({ clickAction, children }) => {
   return (
     <Button 
         onClick={clickAction}
@@ -10,7 +10,7 @@ const ContainedBrownButton = ({ clickAction, label }) => {
             backgroundColor: '#362D2D'
         }}
     >
-        {label}
+        {children}
     </Button>
   )
 }

--- a/ecosphere-goods/src/components/utility/general-buttons/DialogButton.js
+++ b/ecosphere-goods/src/components/utility/general-buttons/DialogButton.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { CircularProgress } from '@mui/material'
 
-const DialogButton = ({ label='', onClick = () => {}, type='', loading=false }) => {
+const DialogButton = ({ children, onClick = () => {}, type='', loading=false }) => {
   return (
     <button onClick={onClick} className='bg-dark-brown p-2 pl-4 pr-4 rounded-full border-2 bg-opacity-0 border-dark-brown hover:bg-opacity-100 hover:text-off-white transition-all ease-in-out duration-300' type='submit'>
       <div className='flex justify-center items-center'>
-        <span className={`${loading ? 'opacity-0' : ''}`}>{label}</span>
+        <span className={`${loading ? 'opacity-0' : ''}`}>{children}</span>
         <CircularProgress color='' size={24} className={`absolute ${loading ? '' : 'opacity-0'}`}/>
       </div>
     </button>

--- a/ecosphere-goods/src/components/utility/general-buttons/OpacityButton.js
+++ b/ecosphere-goods/src/components/utility/general-buttons/OpacityButton.js
@@ -2,7 +2,7 @@ import React from 'react'
 import CircularProgress from '@mui/material/CircularProgress';
 
 // Changes opacity on hover
-const OpacityButton = ({ label, type='', onClick = async () => {}, loading = false, bgColor = 'bg-dark-brown'}) => {
+const OpacityButton = ({ children, type='', onClick = async () => {}, loading = false, bgColor = 'bg-dark-brown'}) => {
 
     const handleClick = async (event) => {
         await onClick(event)
@@ -15,7 +15,7 @@ const OpacityButton = ({ label, type='', onClick = async () => {}, loading = fal
             className={`flex items-center align-middle justify-center text-off-white font-header ${bgColor} p-2 pl-4 pr-4 rounded-lg hover:bg-opacity-85`}
         >
                 <CircularProgress color={'#362D2D'} thickness={6} size={18} className={`absolute w-full h-full text-off-white ${loading ? '' : 'opacity-0'}`}/>
-                <span className={`opacity ${loading ? 'opacity-0' : ''}`}>{label}</span>
+                <span className={`opacity ${loading ? 'opacity-0' : ''}`}>{children}</span>
         </button>
     )
 }

--- a/ecosphere-goods/src/components/utility/general-buttons/UncontainedButton.js
+++ b/ecosphere-goods/src/components/utility/general-buttons/UncontainedButton.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import CircularProgress from '@mui/material/CircularProgress';
 
-const UncontainedButton = ({ label = '', onClick = () => {}, loading = false, bgColor='dark-brown', color='dark-brown', transitionColor='off-white' }) => {
+const UncontainedButton = ({ children, onClick = () => {}, loading = false, bgColor='dark-brown', color='dark-brown', transitionColor='off-white' }) => {
 
     return (
         <button 
@@ -10,7 +10,7 @@ const UncontainedButton = ({ label = '', onClick = () => {}, loading = false, bg
 
         >
             <div className='flex justify-center h-full items-center'>
-                <span className={`${loading ? 'opacity-0' : ''}`}>{label}</span>
+                <span className={`${loading ? 'opacity-0' : ''}`}>{children}</span>
                 <CircularProgress color='#362D2D' size={24} className={`absolute ${loading ? '' : 'opacity-0'}`} thickness={4}/>
             </div>
         </button>


### PR DESCRIPTION
- Using labels was so that you can shorthand the component like so: <Button/>. 
- But sometimes you want icons or other things in your button so this was adjusted 